### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Start Axon
 
 ```
-git clone git@github.com:axonweb3/axon.git
+git clone -b refactor-precompile-input https://github.com/axonweb3/axon.git
 cd axon
-git checkout -b origin/refactor-precompile-input
 cargo run -- run -c devtools/chain/config.toml -s devtools/chain/specs/single_node/chain-spec.toml
 ```
 


### PR DESCRIPTION
## Fix the git clone cmds

1. 
```bash
/tmp via C v9.4.0-gcc via 💎 v3.2.2 
⬢ [Docker] ❯ git clone git@github.com:axonweb3/axon.git
Cloning into 'axon'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

2. `git checkout -b origin/refactor-precompile-input` only creates a new branch, not fetch and switch to origin/refactor-precompile-input